### PR TITLE
docs: Add pkg-config to list of dependencies

### DIFF
--- a/docs/contribute/installation.mdx
+++ b/docs/contribute/installation.mdx
@@ -22,7 +22,7 @@ You'll need to install the following programming tools:
 Ubuntu users can install those dependencies by running:
 
 ```shell
-sudo apt install python3 ninja-build cmake ccache xdelta3 clang libssl-dev
+sudo apt install python3 ninja-build cmake ccache xdelta3 clang libssl-dev pkg-config
 ```
 :::
 


### PR DESCRIPTION
Apparently it's needed by some of our Rust dependencies: https://discord.com/channels/688807550715560050/745633101157498880/1032270930656899142

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/botw-decomp-www/2)
<!-- Reviewable:end -->
